### PR TITLE
Allow deletion of several keys via vararg on StringCommands.del()

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
@@ -25,7 +25,7 @@ trait StringCommands[F[_], K, V]
     with Decrement[F, K, V]
     with Increment[F, K, V]
     with Bits[F, K, V] {
-  def del(key: K): F[Unit]
+  def del(key: K*): F[Unit]
   def expire(k: K, seconds: FiniteDuration): F[Unit]
 }
 

--- a/core/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
@@ -80,9 +80,9 @@ private[fs2redis] class Fs2Redis[F[_], K, V](val client: StatefulRedisConnection
 
   import scala.collection.JavaConverters._
 
-  override def del(key: K): F[Unit] =
+  override def del(key: K*): F[Unit] =
     JRFuture {
-      F.delay(client.async().del(key))
+      F.delay(client.async().del(key: _*))
     }.void
 
   override def expire(key: K, expiresIn: FiniteDuration): F[Unit] =


### PR DESCRIPTION
**Change:**
The Redis `DEL` command can take arbitrary many keys to delete at once and Lettuce models this via a vararg method which is currently not exposed by fs2-redis, it only allows deletion of a single key. This PR introduces the vararg to fs2-redis, replacing the old method. This is source-compatible, but AFAIK not binary-compatible - given the early stage of this project I assume this is fine. Alternatively, one could overload the `del(…)` method.

**Use case:**
Any place where more than one delete is present, they can be merged. For example, we have regular updates on a data set which is split to several keys. After updating, we want to delete all the keys which didn't get updated as they contain outdated information.