### PR TITLE
Implement safe mGet

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
@@ -47,6 +47,7 @@ trait Setter[F[_], K, V] {
 
 trait MultiKey[F[_], K, V] {
   def mGet(keys: Set[K]): F[Map[K, V]]
+  def safeMGet(keys: Set[K]): F[Map[K, V]]
   def mSet(keyValues: Map[K, V]): F[Unit]
   def mSetNx(keyValues: Map[K, V]): F[Unit]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
@@ -47,7 +47,6 @@ trait Setter[F[_], K, V] {
 
 trait MultiKey[F[_], K, V] {
   def mGet(keys: Set[K]): F[Map[K, V]]
-  def safeMGet(keys: Set[K]): F[Map[K, V]]
   def mSet(keyValues: Map[K, V]): F[Unit]
   def mSetNx(keyValues: Map[K, V]): F[Unit]
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
@@ -174,11 +174,6 @@ private[fs2redis] class Fs2Redis[F[_], K, V](val client: StatefulRedisConnection
   override def mGet(keys: Set[K]): F[Map[K, V]] =
     JRFuture {
       F.delay(client.async().mget(keys.toSeq: _*))
-    }.map(_.asScala.toList.map(kv => kv.getKey -> kv.getValue).toMap)
-
-  override def safeMGet(keys: Set[K]): F[Map[K, V]] =
-    JRFuture {
-      F.delay(client.async().mget(keys.toSeq: _*))
     }.map {
       _.asScala.toList.flatMap { kv =>
         if (kv.hasValue)

--- a/core/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
@@ -174,14 +174,7 @@ private[fs2redis] class Fs2Redis[F[_], K, V](val client: StatefulRedisConnection
   override def mGet(keys: Set[K]): F[Map[K, V]] =
     JRFuture {
       F.delay(client.async().mget(keys.toSeq: _*))
-    }.map {
-      _.asScala.toList.flatMap { kv =>
-        if (kv.hasValue)
-          Some(kv.getKey -> kv.getValue)
-        else
-          None
-      }.toMap
-    }
+    }.map(_.asScala.toList.collect { case kv if kv.hasValue => kv.getKey -> kv.getValue }.toMap)
 
   override def mSet(keyValues: Map[K, V]): F[Unit] =
     JRFuture {


### PR DESCRIPTION
mGet should not throw an exception when getting the value from a key which has no value set.