### PR TITLE
Fixing integration between scribe and tut for Scala 2.12.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ organization in ThisBuild := "com.github.gvolpe"
 
 version in ThisBuild := "0.2.0"
 
-crossScalaVersions in ThisBuild := Seq("2.12.4")
+crossScalaVersions in ThisBuild := Seq("2.12.6")
 
 sonatypeProfileName := "com.github.gvolpe"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val catsEffect = "1.0.0-RC3"
     val fs2        = "1.0.0-M4"
     val lettuce    = "5.1.0.M1"
-    val scribe     = "2.3.0"
+    val scribe     = "2.6.0"
 
     val betterMonadicFor  = "0.2.4"
     val kindProjector     = "0.9.7"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,6 +9,8 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.0.0")
 
 addSbtPlugin("com.lucidchart" %  "sbt-scalafmt" % "1.15")
 
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.20")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.23")
+
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.7")
 
 addSbtPlugin("com.scalapenos" % "sbt-prompt" % "1.0.2")


### PR DESCRIPTION
By manually adding the `Tut plugin 0.6.7` overriding the one used by `sbt-microsites`. It as fixed here: https://github.com/tpolecat/tut/issues/231

Definitely closes https://github.com/outr/scribe/issues/80