### PR TITLE
Adding Log4cats support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ And this for the Streams API (depends on `fs2` and `cats-effect`):
 libraryDependencies += "com.github.gvolpe" %% "fs2-redis-streams" % Version
 ```
 
+### Log4cats support
+
+`fs2-redis` needs a logger for internal use and provides instances for `log4cats`. It is the recommended logging library:
+
+```
+libraryDependencies += "com.github.gvolpe" %% "fs2-redis-log4cats" % Version
+```
+
 ## LICENSE
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this project except in compliance with

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,6 @@ val commonSettings = Seq(
     compilerPlugin(Libraries.betterMonadicFor),
     Libraries.redisClient,
     Libraries.catsEffect,
-    Libraries.scribe,
     Libraries.scalaTest % Test,
     Libraries.scalaCheck % Test
   ),
@@ -79,6 +78,13 @@ lazy val `fs2-redis-core` = project.in(file("core"))
   .settings(parallelExecution in Test := false)
   .enablePlugins(AutomateHeaderPlugin)
 
+lazy val `fs2-redis-log4cats` = project.in(file("log4cats"))
+  .settings(commonSettings: _*)
+  .settings(libraryDependencies += Libraries.log4CatsCore)
+  .settings(parallelExecution in Test := false)
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(`fs2-redis-core`)
+
 lazy val `fs2-redis-effects` = project.in(file("effects"))
   .settings(commonSettings: _*)
   .settings(parallelExecution in Test := false)
@@ -95,7 +101,9 @@ lazy val `fs2-redis-streams` = project.in(file("streams"))
 lazy val examples = project.in(file("examples"))
   .settings(commonSettings: _*)
   .settings(noPublish)
+  .settings(libraryDependencies += Libraries.log4CatsSlf4j)
   .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(`fs2-redis-log4cats`)
   .dependsOn(`fs2-redis-effects`)
   .dependsOn(`fs2-redis-streams`)
 

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisClusterStringsDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisClusterStringsDemo.scala
@@ -16,17 +16,18 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.StringCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClusterClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 
-object Fs2RedisClusterStringsDemo extends IOApp {
+object Fs2RedisClusterStringsDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =
@@ -54,7 +55,6 @@ object Fs2RedisClusterStringsDemo extends IOApp {
           _ <- showResult(z)
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisGeoDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisGeoDemo.scala
@@ -16,19 +16,20 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.GeoCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
-import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.effects._
+import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 import io.lettuce.core.GeoArgs
 
-object Fs2RedisGeoDemo extends IOApp {
+object Fs2RedisGeoDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val testKey = "location"
 
     val commandsApi: Resource[IO, GeoCommands[IO, String, String]] =
@@ -57,7 +58,6 @@ object Fs2RedisGeoDemo extends IOApp {
           _ <- putStrLn(s"Geo Radius in 1000 km: $z")
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisHashesDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisHashesDemo.scala
@@ -16,17 +16,18 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.HashCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 
-object Fs2RedisHashesDemo extends IOApp {
+object Fs2RedisHashesDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val testKey   = "foo"
     val testField = "bar"
 
@@ -55,7 +56,6 @@ object Fs2RedisHashesDemo extends IOApp {
           _ <- showResult(z)
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisListsDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisListsDemo.scala
@@ -16,17 +16,18 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.ListCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 
-object Fs2RedisListsDemo extends IOApp {
+object Fs2RedisListsDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val testKey = "listos"
 
     val commandsApi: Resource[IO, ListCommands[IO, String, String]] =
@@ -51,7 +52,6 @@ object Fs2RedisListsDemo extends IOApp {
           _ <- putStrLn(s"Range: $z")
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisMasterSlaveStringsDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisMasterSlaveStringsDemo.scala
@@ -16,18 +16,18 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
 import com.github.gvolpe.fs2redis.connection.Fs2RedisMasterSlave
 import com.github.gvolpe.fs2redis.domain.Fs2RedisMasterSlaveConnection
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 import io.lettuce.core.ReadFrom
 
-object Fs2RedisMasterSlaveStringsDemo extends IOApp {
+object Fs2RedisMasterSlaveStringsDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =
@@ -54,7 +54,6 @@ object Fs2RedisMasterSlaveStringsDemo extends IOApp {
           } yield ()
         }
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisSetsDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisSetsDemo.scala
@@ -16,17 +16,18 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.SetCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 
-object Fs2RedisSetsDemo extends IOApp {
+object Fs2RedisSetsDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val testKey = "foos"
 
     val showResult: Set[String] => IO[Unit] = x => putStrLn(s"$testKey members: $x")
@@ -55,7 +56,6 @@ object Fs2RedisSetsDemo extends IOApp {
           _ <- cmd.sCard(testKey).flatMap(s => putStrLn(s"size: $s"))
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisSortedSetsDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisSortedSetsDemo.scala
@@ -16,18 +16,19 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.SortedSetCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.effects.{ Score, ScoreWithValue, ZRange }
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 
-object Fs2RedisSortedSetsDemo extends IOApp {
+object Fs2RedisSortedSetsDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val testKey = "zztop"
 
     val commandsApi: Resource[IO, SortedSetCommands[IO, String, Long]] =
@@ -48,7 +49,6 @@ object Fs2RedisSortedSetsDemo extends IOApp {
           _ <- putStrLn(s"Count: $z")
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisStringsDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2RedisStringsDemo.scala
@@ -16,17 +16,18 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp, Resource }
-import cats.syntax.all._
+import cats.effect.{ IO, Resource }
+import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.algebra.StringCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 
-object Fs2RedisStringsDemo extends IOApp {
+object Fs2RedisStringsDemo extends LoggerIOApp {
 
   import Demo._
 
-  override def run(args: List[String]): IO[ExitCode] = {
+  def program(implicit log: Log[IO]): IO[Unit] = {
     val usernameKey = "test"
 
     val showResult: Option[String] => IO[Unit] =
@@ -54,7 +55,6 @@ object Fs2RedisStringsDemo extends IOApp {
           _ <- showResult(z)
         } yield ()
       }
-      .as(ExitCode.Success)
   }
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2StreamingDemo.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/Fs2StreamingDemo.scala
@@ -16,11 +16,10 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ExitCode, IO, IOApp }
-import cats.syntax.apply._
-import cats.syntax.functor._
+import cats.effect.IO
 import cats.syntax.parallel._
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
+import com.github.gvolpe.fs2redis.effect.Log
 import com.github.gvolpe.fs2redis.interpreter.streams.Fs2Streaming
 import com.github.gvolpe.fs2redis.streams.StreamingMessage
 import fs2.Stream
@@ -28,7 +27,7 @@ import fs2.Stream
 import scala.concurrent.duration._
 import scala.util.Random
 
-object Fs2StreamingDemo extends IOApp {
+object Fs2StreamingDemo extends LoggerIOApp {
 
   import Demo._
 
@@ -44,7 +43,7 @@ object Fs2StreamingDemo extends IOApp {
     }
   }
 
-  def stream(args: List[String]): Stream[IO, Unit] =
+  def stream(implicit log: Log[IO]): Stream[IO, Unit] =
     for {
       client <- Stream.resource(Fs2RedisClient[IO](redisURI))
       streaming <- Fs2Streaming.mkStreamingConnection[IO, String, String](client, stringCodec, redisURI)
@@ -56,7 +55,7 @@ object Fs2StreamingDemo extends IOApp {
           ).parJoin(2).drain
     } yield ()
 
-  override def run(args: List[String]): IO[ExitCode] =
-    stream(args).compile.drain.as(ExitCode.Success)
+  def program(implicit log: Log[IO]): IO[Unit] =
+    stream.compile.drain
 
 }

--- a/examples/src/main/scala/com/github/gvolpe/fs2redis/LoggerIOApp.scala
+++ b/examples/src/main/scala/com/github/gvolpe/fs2redis/LoggerIOApp.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018-2019 Fs2 Redis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2redis
+
+import cats.effect.{ ExitCode, IO, IOApp }
+import cats.syntax.functor._
+import com.github.gvolpe.fs2redis.effect.Log
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+
+/**
+  * Provides an instance of `Log` given an instance of `Logger`.
+  *
+  * For simplicity and re-usability in all the examples.
+  * */
+trait LoggerIOApp extends IOApp {
+
+  def program(implicit log: Log[IO]): IO[Unit]
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Slf4jLogger
+      .create[IO]
+      .flatMap { implicit logger: Logger[IO] =>
+        program
+      }
+      .as(ExitCode.Success)
+
+}

--- a/log4cats/src/main/scala/com/github/gvolpe/fs2redis/log4cats.scala
+++ b/log4cats/src/main/scala/com/github/gvolpe/fs2redis/log4cats.scala
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-package com.github.gvolpe.fs2redis.effect
+package com.github.gvolpe.fs2redis
 
-/**
-  * Typeclass used for internal logging such as acquiring and releasing connections.
-  *
-  * You should provide an instance. It is recommended to use `log4cats`.
-  * */
-trait Log[F[_]] {
-  def info(msg: => String): F[Unit]
-  def error(msg: => String): F[Unit]
-}
+import com.github.gvolpe.fs2redis.effect.Log
+import io.chrisdavenport.log4cats.Logger
 
-object Log {
-  def apply[F[_]](implicit ev: Log[F]): Log[F] = ev
+object log4cats {
+
+  implicit def log4CatsInstance[F[_]](implicit L: Logger[F]): Log[F] =
+    new Log[F] {
+      def info(msg: => String): F[Unit]  = L.info(msg)
+      def error(msg: => String): F[Unit] = L.error(msg)
+    }
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
     val catsEffect = "1.1.0"
     val fs2        = "1.0.2"
     val lettuce    = "5.1.3.RELEASE"
-    val scribe     = "2.7.1"
+    val log4cats   = "0.2.0"
 
     val betterMonadicFor = "0.2.4"
     val kindProjector    = "0.9.9"
@@ -16,10 +16,14 @@ object Dependencies {
   }
 
   object Libraries {
+    def log4cats(artifact: String): ModuleID = "io.chrisdavenport" %% s"log4cats-$artifact" % Versions.log4cats
+
     lazy val redisClient = "io.lettuce"    % "lettuce-core" % Versions.lettuce
     lazy val catsEffect  = "org.typelevel" %% "cats-effect" % Versions.catsEffect
     lazy val fs2Core     = "co.fs2"        %% "fs2-core"    % Versions.fs2
-    lazy val scribe      = "com.outr"      %% "scribe"      % Versions.scribe
+
+    lazy val log4CatsCore  = log4cats("core")
+    lazy val log4CatsSlf4j = log4cats("slf4j")
 
     // Compiler plugins
     lazy val betterMonadicFor = "com.olegpy"     %% "better-monadic-for" % Versions.betterMonadicFor

--- a/site/src/main/tut/effects/connection.md
+++ b/site/src/main/tut/effects/connection.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.ConnectionCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, ConnectionCommands[IO]] = {
   Fs2Redis[IO, String, String](null, null, null).widen[ConnectionCommands[IO]]

--- a/site/src/main/tut/effects/geo.md
+++ b/site/src/main/tut/effects/geo.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.GeoCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, GeoCommands[IO, String, String]] = {
   Fs2Redis[IO, String, String](null, null, null).map(_.asInstanceOf[GeoCommands[IO, String, String]])

--- a/site/src/main/tut/effects/hashes.md
+++ b/site/src/main/tut/effects/hashes.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.HashCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, HashCommands[IO, String, String]] = {
   Fs2Redis[IO, String, String](null, null, null).map(_.asInstanceOf[HashCommands[IO, String, String]])

--- a/site/src/main/tut/effects/index.md
+++ b/site/src/main/tut/effects/index.md
@@ -18,11 +18,17 @@ The API that operates at the effect level `F[_]` on top of `cats-effect`.
 
 ### Acquiring client and connection
 
-For all the effect-based APIs the process of acquiring a client and a commands connection is exactly the same. The `apply` method returns a `Resource`:
+For all the effect-based APIs the process of acquiring a client and a commands connection is via the `apply` method that returns a `Resource`:
 
 ```scala
 def apply[F[_]](uri: RedisURI): Resource[F, Fs2RedisClient]
 ```
+
+### Logger
+
+In order to create a client and/or connection you must provide a `Log` instance that the library uses for internal logging. You could either create your own or use `log4cats` (recommended). `fs2-redis` can derive an instance of `Log[F]` if there is an instance of `Logger[F]` in scope, just need to `import com.github.gvolpe.fs2redis.log4cats._` and add the extra dependency `fs2-redis-log4cats`.
+
+Take a look at the [examples](https://github.com/gvolpe/fs2-redis/blob/master/examples/src/main/scala/com/github/gvolpe/fs2redis/LoggerIOApp.scala) to find out more.
 
 ### Establishing connection
 

--- a/site/src/main/tut/effects/index.md
+++ b/site/src/main/tut/effects/index.md
@@ -39,14 +39,16 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.StringCommands
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
-import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
 import com.github.gvolpe.fs2redis.domain.{DefaultRedisCodec, Fs2RedisCodec}
+import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
 import io.lettuce.core.RedisURI
 import io.lettuce.core.codec.{RedisCodec, StringCodec}
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val redisURI: RedisURI                         = RedisURI.create("redis://localhost")
 val stringCodec: Fs2RedisCodec[String, String] = DefaultRedisCodec(StringCodec.UTF8)

--- a/site/src/main/tut/effects/index.md
+++ b/site/src/main/tut/effects/index.md
@@ -26,7 +26,7 @@ def apply[F[_]](uri: RedisURI): Resource[F, Fs2RedisClient]
 
 ### Logger
 
-In order to create a client and/or connection you must provide a `Log` instance that the library uses for internal logging. You could either create your own or use `log4cats` (recommended). `fs2-redis` can derive an instance of `Log[F]` if there is an instance of `Logger[F]` in scope, just need to `import com.github.gvolpe.fs2redis.log4cats._` and add the extra dependency `fs2-redis-log4cats`.
+In order to create a client and/or connection you must provide a `Log` instance that the library uses for internal logging. You could either create your own or use `log4cats` (recommended). `fs2-redis` can derive an instance of `Log[F]` if there is an instance of `Logger[F]` in scope, just need to add the extra dependency `fs2-redis-log4cats` and `import com.github.gvolpe.fs2redis.log4cats._`.
 
 Take a look at the [examples](https://github.com/gvolpe/fs2-redis/blob/master/examples/src/main/scala/com/github/gvolpe/fs2redis/LoggerIOApp.scala) to find out more.
 

--- a/site/src/main/tut/effects/lists.md
+++ b/site/src/main/tut/effects/lists.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.ListCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, ListCommands[IO, String, String]] = {
   Fs2Redis[IO, String, String](null, null, null).map(_.asInstanceOf[ListCommands[IO, String, String]])

--- a/site/src/main/tut/effects/server.md
+++ b/site/src/main/tut/effects/server.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.ServerCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, ServerCommands[IO]] = {
   Fs2Redis[IO, String, String](null, null, null).widen[ServerCommands[IO]]

--- a/site/src/main/tut/effects/sets.md
+++ b/site/src/main/tut/effects/sets.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.SetCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, SetCommands[IO, String, String]] = {
   Fs2Redis[IO, String, String](null, null, null).map(_.asInstanceOf[SetCommands[IO, String, String]])

--- a/site/src/main/tut/effects/sortedsets.md
+++ b/site/src/main/tut/effects/sortedsets.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.SortedSetCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, SortedSetCommands[IO, String, Long]] = {
   Fs2Redis[IO, String, String](null, null, null).map(_.asInstanceOf[SortedSetCommands[IO, String, Long]])

--- a/site/src/main/tut/effects/strings.md
+++ b/site/src/main/tut/effects/strings.md
@@ -13,10 +13,12 @@ import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.StringCommands
 import com.github.gvolpe.fs2redis.interpreter.Fs2Redis
+import com.github.gvolpe.fs2redis.log4cats._
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 
-import scala.concurrent.ExecutionContext
-
-implicit val cs = IO.contextShift(ExecutionContext.global)
+implicit val cs = IO.contextShift(scala.concurrent.ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val commandsApi: Resource[IO, StringCommands[IO, String, String]] = {
   Fs2Redis[IO, String, String](null, null, null).map(_.asInstanceOf[StringCommands[IO, String, String]])

--- a/site/src/main/tut/streams/pubsub.md
+++ b/site/src/main/tut/streams/pubsub.md
@@ -56,9 +56,12 @@ When using the `Fs2PubSub` interpreter the `publish` function will be defined as
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.apply._
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
-import com.github.gvolpe.fs2redis.interpreter.pubsub.Fs2PubSub
 import com.github.gvolpe.fs2redis.domain.{DefaultChannel, DefaultRedisCodec}
+import com.github.gvolpe.fs2redis.interpreter.pubsub.Fs2PubSub
+import com.github.gvolpe.fs2redis.log4cats._
 import fs2.{Sink, Stream}
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.lettuce.core.RedisURI
 import io.lettuce.core.codec.StringCodec
 
@@ -66,6 +69,8 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 object Fs2PubSubDemo extends IOApp {
+
+  implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
   private val redisURI    = RedisURI.create("redis://localhost")
   private val stringCodec = DefaultRedisCodec(StringCodec.UTF8)

--- a/site/src/main/tut/streams/streams.md
+++ b/site/src/main/tut/streams/streams.md
@@ -31,7 +31,7 @@ def mkMasterSlaveConnection[F[_], K, V](codec: Fs2RedisCodec[K, V], uris: RedisU
 
 #### Cluster connection
 
-Not implemented yet. 
+Not implemented yet.
 
 ### Streaming API
 
@@ -52,10 +52,13 @@ trait Streaming[F[_], K, V] {
 import cats.effect.IO
 import cats.syntax.parallel._
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
-import com.github.gvolpe.fs2redis.interpreter.streams.Fs2Streaming
 import com.github.gvolpe.fs2redis.domain._
+import com.github.gvolpe.fs2redis.interpreter.streams.Fs2Streaming
+import com.github.gvolpe.fs2redis.log4cats._
 import com.github.gvolpe.fs2redis.streams._
 import fs2.Stream
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.lettuce.core.RedisURI
 import io.lettuce.core.codec.StringCodec
 
@@ -65,6 +68,7 @@ import scala.util.Random
 
 implicit val timer = IO.timer(ExecutionContext.global)
 implicit val cs    = IO.contextShift(ExecutionContext.global)
+implicit val logger: Logger[IO] = Slf4jLogger.unsafeCreate[IO]
 
 val redisURI    = RedisURI.create("redis://localhost")
 val stringCodec = DefaultRedisCodec(StringCodec.UTF8)

--- a/streams/src/main/scala/com/github/gvolpe/fs2redis/interpreter/pubsub/Fs2PubSubCommands.scala
+++ b/streams/src/main/scala/com/github/gvolpe/fs2redis/interpreter/pubsub/Fs2PubSubCommands.scala
@@ -23,11 +23,11 @@ import com.github.gvolpe.fs2redis.algebra.{ PubSubCommands, PubSubStats, Subscri
 import com.github.gvolpe.fs2redis.domain.Fs2RedisChannel
 import com.github.gvolpe.fs2redis.interpreter.pubsub.internals.{ Fs2PubSubInternals, PubSubState }
 import com.github.gvolpe.fs2redis.streams.Subscription
-import com.github.gvolpe.fs2redis.effect.JRFuture
+import com.github.gvolpe.fs2redis.effect.{ JRFuture, Log }
 import fs2.Stream
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
 
-class Fs2PubSubCommands[F[_]: ConcurrentEffect: ContextShift, K, V](
+class Fs2PubSubCommands[F[_]: ConcurrentEffect: ContextShift: Log, K, V](
     state: Ref[F, PubSubState[F, K, V]],
     subConnection: StatefulRedisPubSubConnection[K, V],
     pubConnection: StatefulRedisPubSubConnection[K, V]

--- a/streams/src/main/scala/com/github/gvolpe/fs2redis/interpreter/pubsub/Fs2Subscriber.scala
+++ b/streams/src/main/scala/com/github/gvolpe/fs2redis/interpreter/pubsub/Fs2Subscriber.scala
@@ -22,12 +22,12 @@ import cats.syntax.all._
 import com.github.gvolpe.fs2redis.algebra.SubscribeCommands
 import com.github.gvolpe.fs2redis.interpreter.pubsub.internals.{ Fs2PubSubInternals, PubSubState }
 import com.github.gvolpe.fs2redis.domain.Fs2RedisChannel
-import com.github.gvolpe.fs2redis.effect.JRFuture
+import com.github.gvolpe.fs2redis.effect.{ JRFuture, Log }
 import fs2.Stream
 import fs2.concurrent.Topic
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection
 
-class Fs2Subscriber[F[_]: ConcurrentEffect: ContextShift, K, V](
+class Fs2Subscriber[F[_]: ConcurrentEffect: ContextShift: Log, K, V](
     state: Ref[F, PubSubState[F, K, V]],
     subConnection: StatefulRedisPubSubConnection[K, V]
 ) extends SubscribeCommands[Stream[F, ?], K, V] {

--- a/test-support/src/main/scala/com/github/gvolpe/fs2redis/DockerRedis.scala
+++ b/test-support/src/main/scala/com/github/gvolpe/fs2redis/DockerRedis.scala
@@ -16,7 +16,7 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ContextShift, IO }
+import cats.effect.{ Clock, ContextShift, IO, Timer }
 import cats.syntax.apply._
 import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClient
@@ -32,7 +32,7 @@ import scala.util.Random
 
 // Highly-inspired by DockerCassandra -> https://github.com/Spinoco/fs2-cassandra/blob/series/0.4/test-support/src/main/scala/spinoco/fs2/cassandra/support/DockerCassandra.scala
 trait DockerRedis extends BeforeAndAfterAll with BeforeAndAfterEach { self: Suite =>
-  import DockerRedis._
+  import DockerRedis._, testLogger._
 
   // override this if the Redis container has to be started before invocation
   // when developing tests, this likely shall be false, so there is no additional overhead starting Redis
@@ -47,7 +47,9 @@ trait DockerRedis extends BeforeAndAfterAll with BeforeAndAfterEach { self: Suit
 
   private var dockerInstanceId: Option[String] = None
 
-  implicit val cts: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  implicit val cs: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val timer: Timer[IO]     = IO.timer(ExecutionContext.global)
+  implicit val clock: Clock[IO]     = timer.clock
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/test-support/src/main/scala/com/github/gvolpe/fs2redis/RedisClusterTest.scala
+++ b/test-support/src/main/scala/com/github/gvolpe/fs2redis/RedisClusterTest.scala
@@ -16,7 +16,7 @@
 
 package com.github.gvolpe.fs2redis
 
-import cats.effect.{ ContextShift, IO }
+import cats.effect.{ Clock, ContextShift, IO, Timer }
 import cats.syntax.apply._
 import cats.syntax.functor._
 import com.github.gvolpe.fs2redis.connection.Fs2RedisClusterClient
@@ -29,7 +29,7 @@ import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, Suite }
 import scala.concurrent.ExecutionContext
 
 trait RedisClusterTest extends BeforeAndAfterAll with BeforeAndAfterEach { self: Suite =>
-  import DockerRedis._
+  import DockerRedis._, testLogger._
 
   // override this if the Redis container has to be started before invocation
   // when developing tests, this likely shall be false, so there is no additional overhead starting Redis
@@ -47,7 +47,9 @@ trait RedisClusterTest extends BeforeAndAfterAll with BeforeAndAfterEach { self:
     "redis://localhost:30003"
   ).map(RedisURI.create)
 
-  implicit val cts: ContextShift[IO] = IO.contextShift(ExecutionContext.Implicits.global)
+  implicit val cts: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
+  implicit val timer: Timer[IO]      = IO.timer(ExecutionContext.global)
+  implicit val clock: Clock[IO]      = timer.clock
 
   private val stringCodec = DefaultRedisCodec(StringCodec.UTF8)
 

--- a/test-support/src/main/scala/com/github/gvolpe/fs2redis/testLogger.scala
+++ b/test-support/src/main/scala/com/github/gvolpe/fs2redis/testLogger.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2019 Fs2 Redis
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.gvolpe.fs2redis
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+import cats.Functor
+import cats.effect.{ Clock, Sync }
+import cats.syntax.all._
+import com.github.gvolpe.fs2redis.effect.Log
+
+object testLogger {
+
+  private def putStrLn[F[_]: Sync, A](a: A): F[Unit] = Sync[F].delay(println(a))
+
+  private def timestamp[F[_]: Clock: Functor]: F[String] =
+    Clock[F].realTime(TimeUnit.MILLISECONDS).map(Instant.ofEpochMilli(_).toString)
+
+  private def log[F[_]: Clock: Sync, A](level: String)(a: A): F[Unit] =
+    timestamp[F].flatMap { t =>
+      putStrLn(s"[${level.toUpperCase}] - [$t] - $a")
+    }
+
+  implicit def instance[F[_]: Clock: Sync]: Log[F] =
+    new Log[F] {
+      def info(msg: => String): F[Unit]  = log("info")(msg)
+      def error(msg: => String): F[Unit] = log("error")(msg)
+    }
+
+}


### PR DESCRIPTION
This PR introduces a new module, that will be published as `fs2-redis-log4cats`, where an instance for the internal typeclass `Log[F]` can be derived if there's an instance of `Logger[F]` in scope.

In this way, the modules `core`, `effects` and `streams` avoid having `log4cats` as a dependency. Instead, the user has the option to either provide their own instance of `Log[F]` (which is much simpler than `Logger[F]`, since for internal use only `info` and `error` are required) or use the `log4cats` module if they prefer to use this external library which is recommended.

Will appreciate your review @kubukoz , thanks :)