### PR TITLE
Changed *setNx API signatures

### DIFF
--- a/effects/src/main/scala/com/github/gvolpe/fs2redis/algebra/hashes.scala
+++ b/effects/src/main/scala/com/github/gvolpe/fs2redis/algebra/hashes.scala
@@ -33,7 +33,7 @@ trait HashGetter[F[_], K, V] {
 
 trait HashSetter[F[_], K, V] {
   def hSet(key: K, field: K, value: V): F[Unit]
-  def hSetNx(key: K, field: K, value: V): F[Unit]
+  def hSetNx(key: K, field: K, value: V): F[Boolean]
   def hmSet(key: K, fieldValues: Map[K, V]): F[Unit]
 }
 

--- a/effects/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
+++ b/effects/src/main/scala/com/github/gvolpe/fs2redis/algebra/strings.scala
@@ -40,7 +40,7 @@ trait Setter[F[_], K, V] {
   def append(key: K, value: V): F[Unit]
   def getSet(key: K, value: V): F[Option[V]]
   def set(key: K, value: V): F[Unit]
-  def setNx(key: K, value: V): F[Unit]
+  def setNx(key: K, value: V): F[Boolean]
   def setEx(key: K, value: V, expiresIn: FiniteDuration): F[Unit]
   def setRange(key: K, value: V, offset: Long): F[Unit]
 }
@@ -48,7 +48,7 @@ trait Setter[F[_], K, V] {
 trait MultiKey[F[_], K, V] {
   def mGet(keys: Set[K]): F[Map[K, V]]
   def mSet(keyValues: Map[K, V]): F[Unit]
-  def mSetNx(keyValues: Map[K, V]): F[Unit]
+  def mSetNx(keyValues: Map[K, V]): F[Boolean]
 }
 
 trait Decrement[F[_], K, V] {

--- a/effects/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
+++ b/effects/src/main/scala/com/github/gvolpe/fs2redis/interpreter/Fs2Redis.scala
@@ -132,10 +132,11 @@ private[fs2redis] class BaseFs2Redis[F[_]: ContextShift, K, V](
       conn.async.flatMap(c => F.delay(c.set(key, value)))
     }.void
 
-  override def setNx(key: K, value: V): F[Unit] =
+  override def setNx(key: K, value: V): F[Boolean] =
     JRFuture {
       conn.async.flatMap(c => F.delay(c.setnx(key, value)))
-    }.void
+    }.map(x => Boolean.box(x))
+
 
   override def setEx(key: K, value: V, expiresIn: FiniteDuration): F[Unit] = {
     val command = expiresIn.unit match {
@@ -207,10 +208,10 @@ private[fs2redis] class BaseFs2Redis[F[_]: ContextShift, K, V](
       conn.async.flatMap(c => F.delay(c.mset(keyValues.asJava)))
     }.void
 
-  override def mSetNx(keyValues: Map[K, V]): F[Unit] =
+  override def mSetNx(keyValues: Map[K, V]): F[Boolean] =
     JRFuture {
       conn.async.flatMap(c => F.delay(c.msetnx(keyValues.asJava)))
-    }.void
+    }.map(x => Boolean.box(x))
 
   override def bitCount(key: K): F[Long] =
     JRFuture {
@@ -308,10 +309,10 @@ private[fs2redis] class BaseFs2Redis[F[_]: ContextShift, K, V](
       conn.async.flatMap(c => F.delay(c.hset(key, field, value)))
     }.void
 
-  override def hSetNx(key: K, field: K, value: V): F[Unit] =
+  override def hSetNx(key: K, field: K, value: V): F[Boolean] =
     JRFuture {
       conn.async.flatMap(c => F.delay(c.hsetnx(key, field, value)))
-    }.void
+    }.map(x => Boolean.box(x))
 
   override def hmSet(key: K, fieldValues: Map[K, V]): F[Unit] =
     JRFuture {

--- a/tests/src/test/scala/com/github/gvolpe/fs2redis/Fs2RedisClusterSpec.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2redis/Fs2RedisClusterSpec.scala
@@ -33,7 +33,7 @@ class Fs2RedisClusterSpec extends FunSuite with RedisClusterTest with Fs2TestSce
     withAbstractRedisCluster[Unit, String, Long](sortedSetsScenario)(DefaultRedisCodec(LongCodec))
   )
 
-  test("cluster: strings api")(withRedisCluster(stringsScenario))
+  test("cluster: strings api")(withRedisCluster(stringsClusterScenario))
 
   test("cluster: connection api")(withRedisCluster(connectionScenario))
 

--- a/tests/src/test/scala/com/github/gvolpe/fs2redis/Fs2TestScenarios.scala
+++ b/tests/src/test/scala/com/github/gvolpe/fs2redis/Fs2TestScenarios.scala
@@ -149,6 +149,25 @@ trait Fs2TestScenarios {
     } yield ()
   }
 
+  def stringsClusterScenario(cmd: Fs2Redis.RedisCommands[IO, String, String]): IO[Unit] = {
+    val key = "test"
+    for {
+      x <- cmd.get(key)
+      _ <- IO { assert(x.isEmpty) }
+      isSet1 <- cmd.setNx(key, "some value")
+      _ <- IO { assert(isSet1) }
+      y <- cmd.get(key)
+      _ <- IO { assert(y.contains("some value")) }
+      isSet2 <- cmd.setNx(key, "should not happen")
+      _ <- IO { assert(!isSet2) }
+      w <- cmd.get(key)
+      _ <- IO { assert(w.contains("some value")) }
+      _ <- cmd.del(key)
+      z <- cmd.get(key)
+      _ <- IO { assert(z.isEmpty) }
+    } yield ()
+  }
+
   def connectionScenario(cmd: Fs2Redis.RedisCommands[IO, String, String]): IO[Unit] =
     for {
       pong <- cmd.ping


### PR DESCRIPTION
closes #58 

Changed signature of `*setNx` methods so they return `F[Boolean]` instead of `F[Unit]`.